### PR TITLE
fix: enum.item syntactic sugar add support for terms/descriptions list

### DIFF
--- a/test.typ
+++ b/test.typ
@@ -28,6 +28,12 @@
 3.
 +
 
+/ Terms 1: 描述
+  也是可以的
+  / Terms 2: 有空 格
+  / Terms 3: 没空
+    格
+
 #import "@preview/cuti:0.3.0": *
 #show: show-cn-fakebold
 只检查 text 间的空格，其他类型不会去掉：\

--- a/transform-childs.typ
+++ b/transform-childs.typ
@@ -63,6 +63,8 @@
       ("radicand",)
     } else if func == math.op {
       ("text",)
+    } else if func == terms.item {
+      ("term", "description")
     } else {
       // has no fields?
       none


### PR DESCRIPTION
# Pull Request Description

## Fix `enum.item` syntactic sugar
This PR addresses robustness issues similar to #3 and fixes compilation errors observed in Webapp (Compiler Typst 0.14.2) / Tinymist v0.14.4.

### Minimal Reproducible Example
Even though `test.typ` contains `+` list items, but the file fails to compile in newer environments.
```typst
#import "@preview/cjk-unbreak:0.2.1": remove-cjk-break-space
#show: remove-cjk-break-space
+ 
```
**Error**: `package @preview/cjk-unbreak:0.2.1: Unexpected argument`

### Fix Solution
Dynamically check for the "number" field to support both auto-numbered (`+ item`) and explicitly numbered (`1. item`) lists without crashing.

## Add support for Description Lists (`terms.item`)

### Minimal Reproducible Example

#### Before

```typst
#import "@preview/cjk-unbreak:0.2.1": remove-cjk-break-space
#show: remove-cjk-break-space

/ Terms Or Description: 描 述
  的换行好像不行
```

<img width="450" height="70" alt="image" src="https://github.com/user-attachments/assets/888aa9c6-4640-46ac-9686-2009e3756cc8" />

#### After

```typst
/ Terms 1: 描述
  也是可以的
  / Terms 2: 有空 格
  / Terms 3: 没空
    格
```

<img width="306" height="149" alt="image" src="https://github.com/user-attachments/assets/8e12118f-b368-43ca-bae3-b83fd0c8ce53" />


