### PR TITLE
fix: handle empty sequences

### DIFF
--- a/remove-cjk-break-space.typ
+++ b/remove-cjk-break-space.typ
@@ -25,7 +25,7 @@
 
 #let remove-cjk-break-space(rest) = {
   rest = transform-childs(rest, remove-cjk-break-space)
-  if utils.is-sequence(rest) {
+  if utils.is-sequence(rest) and rest.children.len() != 0 {
     let first = none
     let mid = none
     for third in rest.children {

--- a/test.typ
+++ b/test.typ
@@ -26,6 +26,7 @@
 2. 没空
   格
 3.
++ 有内容有空 格
 +
 
 / Terms 1: 描述
@@ -71,3 +72,11 @@ $underbrace(a, b)$ a 应该在上面  \
 )
 
 http://example.com
+
+// some tests and notes for AST content type
+#assert(type([]) == content)
+#assert(type([a]) == content)
+#assert(type([a] + [b]) == content)
+#assert([].func() == ([a] + [b]).func())
+#assert([a].func() == text)
+#assert([].func() != text)

--- a/transform-childs.typ
+++ b/transform-childs.typ
@@ -84,8 +84,12 @@
 #let transform-childs(it, transform-func) = {
   if type(it) == content {
     if utils.is-sequence(it) {
-      for item in it.children {
-        transform-func(item)
+      if it.children.len() == 0 {
+        it // it == []
+      } else {
+        for item in it.children {
+          transform-func(item)
+        }
       }
     } else if utils.is-styled(it) {
       let child = transform-func(it.child)


### PR DESCRIPTION
This PR fixes the problem where `transform-childs` and `remove-cjk-break-space` convert the empty sequence, like `[]`, to `none`. These two functions should keep the empty sequence as a sequence.

This issue was first discovered after the changes in #4 with Typst 0.13.0.