### PR TITLE
fix: handle `rotate` and parameters that are `Positional` but not `Required`

### DIFF
--- a/test.typ
+++ b/test.typ
@@ -60,7 +60,10 @@ abc。
 去掉的是 `[ ]` 这种空格
 
 #place(bottom, float: true)[23333]
+#place[2333]
+
 #align(center)[6666]
+#align[6666]
 
 $underbrace(a, b)$ a 应该在上面  \
 #math.underbrace("a", "b")<underbrace-label> a 应该在上面
@@ -85,3 +88,6 @@ http://example.com
   你好。
   abc。
   你好]
+
+#rotate[ rotate 没空
+  格]

--- a/test.typ
+++ b/test.typ
@@ -80,3 +80,8 @@ http://example.com
 #assert([].func() == ([a] + [b]).func())
 #assert([a].func() == text)
 #assert([].func() != text)
+
+#rotate(2deg)[你好。abc。你好\
+  你好。
+  abc。
+  你好]

--- a/transform-childs.typ
+++ b/transform-childs.typ
@@ -39,6 +39,8 @@
       }
     } else if func in (place, align) {
       ("alignment", "body")
+    } else if func == rotate {
+      ("angle", "body")
     } else {
       ("body",)
     }

--- a/transform-childs.typ
+++ b/transform-childs.typ
@@ -31,6 +31,8 @@
       ("body", "annotation")
     } else if func == link {
       ("dest", "body")
+    } else if func == rotate {
+      ("angle", "body")
     } else if func == enum.item {
       if it.has("number") {
         ("number", "body")
@@ -39,8 +41,6 @@
       }
     } else if func in (place, align) {
       ("alignment", "body")
-    } else if func == rotate {
-      ("angle", "body")
     } else {
       ("body",)
     }

--- a/transform-childs.typ
+++ b/transform-childs.typ
@@ -31,18 +31,29 @@
       ("body", "annotation")
     } else if func == link {
       ("dest", "body")
-    } else if func == rotate {
-      ("angle", "body")
-    } else if func == enum.item {
-      if it.has("number") {
-        ("number", "body")
+    } else {
+      // Handle parameters that are `Positional` but not `Required`.
+      if func == rotate {
+        if it.has("angle") {
+          ("angle", "body")
+        } else {
+          ("body",)
+        }
+      } else if func == enum.item {
+        if it.has("number") {
+          ("number", "body")
+        } else {
+          ("body",)
+        }
+      } else if func in (place, align) {
+        if it.has("alignment") {
+          ("alignment", "body")
+        } else {
+          ("body",)
+        }
       } else {
         ("body",)
       }
-    } else if func in (place, align) {
-      ("alignment", "body")
-    } else {
-      ("body",)
     }
   } else if it.has("children") {
     ("children",)


### PR DESCRIPTION
# Before

```typst
#import "@preview/cjk-unbreak:0.2.2": *
#show: remove-cjk-break-space

#rotate(5deg)[Hello!]
```

<img width="1197" height="175" alt="image" src="https://github.com/user-attachments/assets/afe598a2-cef9-4f61-aba2-c05b1f79c05b" />

# After

```typst
#rotate(2deg)[你好。abc。你好\
  你好。
  abc。
  你好]
```

<img width="303" height="141" alt="image" src="https://github.com/user-attachments/assets/786b1b2a-c48a-406e-81a3-df1ad436a0bf" />
